### PR TITLE
Updated jetty-alpn-agent version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 ## Or manually creating and running uber-jar
 
     $ ./gradlew build
-    $ java -javaagent:lib/jetty-alpn-agent-2.0.4.jar -jar build/libs/demo-0.0.1-SNAPSHOT.jar
+    $ java -javaagent:lib/jetty-alpn-agent-2.0.5.jar -jar build/libs/demo-0.0.1-SNAPSHOT.jar
 
 On the command-line it should finalize startup with these log lines.
 


### PR DESCRIPTION
With respect to **alpnAgentVersion** in https://github.com/otrosien/demo-http2/blob/master/build.gradle#L4